### PR TITLE
Explicitly control command `cwd`s.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## 0.2.0
+
+Guarantee commands are run in the root project dir or else the custom
+`cwd` project sub-dir defined for the command.
+
 ## 0.1.1
 
 Update project metadata.

--- a/dev_cmd/__init__.py
+++ b/dev_cmd/__init__.py
@@ -1,4 +1,4 @@
 # Copyright 2024 John Sirois.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "0.1.1"
+__version__ = "0.2.0"

--- a/dev_cmd/model.py
+++ b/dev_cmd/model.py
@@ -4,7 +4,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict, Iterable, Mapping, Optional, Tuple
+from pathlib import PurePath
+from typing import Any, Iterable, Mapping
 
 from dev_cmd.errors import InvalidModelError
 
@@ -13,24 +14,25 @@ from dev_cmd.errors import InvalidModelError
 class Command:
     name: str
     env: Mapping[str, str]
-    args: Tuple[str, ...]
+    args: tuple[str, ...]
+    cwd: PurePath
     accepts_extra_args: bool
 
 
 @dataclass(frozen=True)
 class Dev:
     commands: Mapping[str, Command]
-    aliases: Mapping[str, Tuple[Command, ...]]
-    default: Optional[Tuple[str, Tuple[Command, ...]]] = None
+    aliases: Mapping[str, tuple[Command, ...]]
+    default: tuple[str, tuple[Command, ...]] | None = None
     source: Any = "<code>"
 
 
 @dataclass(frozen=True)
 class Invocation:
     @classmethod
-    def create(cls, *tasks: Tuple[str, Iterable[Command]]) -> Invocation:
-        _tasks: Dict[str, Tuple[Command, ...]] = {}
-        accepts_extra_args: Optional[Command] = None
+    def create(cls, *tasks: tuple[str, Iterable[Command]]) -> Invocation:
+        _tasks: dict[str, tuple[Command, ...]] = {}
+        accepts_extra_args: Command | None = None
         for task, commands in tasks:
             _tasks[task] = tuple(commands)
             for command in commands:
@@ -45,5 +47,5 @@ class Invocation:
 
         return cls(tasks=_tasks, accepts_extra_args=accepts_extra_args is not None)
 
-    tasks: Mapping[str, Tuple[Command, ...]]
+    tasks: Mapping[str, tuple[Command, ...]]
     accepts_extra_args: bool

--- a/dev_cmd/project.py
+++ b/dev_cmd/project.py
@@ -1,11 +1,13 @@
 # Copyright 2024 John Sirois.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 from importlib import metadata
 from importlib.metadata import PackageNotFoundError
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
 
 from dev_cmd.errors import InvalidProjectError
 
@@ -23,7 +25,7 @@ except ImportError:
 class PyProjectToml:
     path: Path
 
-    def parse(self) -> Dict[str, Any]:
+    def parse(self) -> dict[str, Any]:
         try:
             with self.path.open("rb") as fp:
                 return toml.load(fp)
@@ -38,13 +40,13 @@ def find_pyproject_toml() -> PyProjectToml:
         dist_files = metadata.files("dev")
         if dist_files and any(module == dist_file.locate() for dist_file in dist_files):
             # N.B.: We're running from an installed package; so use the PWD as the search start.
-            start = Path().resolve()
+            start = Path()
     except PackageNotFoundError:
         # N.B.: We're being run directly from sources that are not installed or are installed in
         # editable mode.
         pass
 
-    candidate = start
+    candidate = start.resolve()
     while True:
         pyproject_toml = candidate / "pyproject.toml"
         if pyproject_toml.is_file():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,26 @@ line-length = 100
 extend-select = ["I"]
 
 [tool.dev-cmd.commands]
+clean = [
+    "python",
+    "-c",
+    """\
+import os
+import shutil
+import sys
+
+import colors
+
+
+# The MyPy cache can get corrupted by swithing Pythons with `uv ... --python ...` and re-building
+# the .venv is cheap; so we clean these as a more restricted form than `git clean -fdx`
+for cache_dir in '.mypy_cache', '.venv':
+    if os.path.exists(cache_dir):
+        shutil.rmtree(cache_dir, ignore_errors=True)
+        print(colors.green(f"Removed directory `{cache_dir}`."), file=sys.stderr)
+    """
+]
+
 fmt = ["ruff", "format"]
 check-fmt = ["ruff", "format", "--diff"]
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,5 +1,6 @@
 # Copyright 2024 John Sirois.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+from pathlib import PurePath
 
 import pytest
 
@@ -8,23 +9,23 @@ from dev_cmd.model import Command, Invocation
 
 
 def test_invocation_create_no_extra_args():
-    command = Command("foo", env={}, args=(), accepts_extra_args=False)
+    command = Command("foo", env={}, args=(), cwd=PurePath(), accepts_extra_args=False)
     invocation = Invocation.create(("foo", [command]))
     assert not invocation.accepts_extra_args
     assert {"foo": (command,)} == invocation.tasks
 
 
 def test_invocation_create_accepts_extra_args():
-    foo = Command("foo", env={}, args=(), accepts_extra_args=True)
-    bar = Command("bar", env={}, args=(), accepts_extra_args=False)
+    foo = Command("foo", env={}, args=(), cwd=PurePath(), accepts_extra_args=True)
+    bar = Command("bar", env={}, args=(), cwd=PurePath(), accepts_extra_args=False)
     invocation = Invocation.create(("foo", [foo]), ("bar", [bar]))
     assert invocation.accepts_extra_args
     assert {"foo": (foo,), "bar": (bar,)} == invocation.tasks
 
 
 def test_invocation_create_multiple_extra_args():
-    foo = Command("foo", env={}, args=(), accepts_extra_args=True)
-    bar = Command("bar", env={}, args=(), accepts_extra_args=True)
+    foo = Command("foo", env={}, args=(), cwd=PurePath(), accepts_extra_args=True)
+    bar = Command("bar", env={}, args=(), cwd=PurePath(), accepts_extra_args=True)
     with pytest.raises(
         InvalidModelError,
         match=(


### PR DESCRIPTION
When commands are run, they now use a `cwd` of the project root
directory or else the custom `cwd` project sub-directory specified for
the command.